### PR TITLE
計測ステータスコンポーネントを追加

### DIFF
--- a/src/components/AccelerationWave.stories.tsx
+++ b/src/components/AccelerationWave.stories.tsx
@@ -1,0 +1,26 @@
+import { useState } from '@storybook/addons';
+import type { ComponentMeta, ComponentStoryFn } from '@storybook/react';
+import { AccelerationWave } from './AccelerationWave';
+
+export default {
+  component: AccelerationWave,
+} as ComponentMeta<typeof AccelerationWave>;
+
+export const Example: ComponentStoryFn<typeof AccelerationWave> = (args) => {
+  const fixedArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  const [array, setArray] = useState<number[]>(fixedArray);
+
+  const next = () => {
+    const last = array[array.length - 1];
+    if (last == null) return;
+    const newArray = [last, ...array.slice(0, array.length - 1)];
+    setArray(newArray);
+  };
+
+  return (
+    <>
+      <AccelerationWave accelerationList={array} />
+      <button onClick={() => next()}>進む</button>
+    </>
+  );
+};

--- a/src/components/AccelerationWave.tsx
+++ b/src/components/AccelerationWave.tsx
@@ -1,0 +1,49 @@
+import { makeWavePath } from '#/features/wave';
+import { FC, useMemo } from 'react';
+
+type Props = {
+  accelerationList: number[];
+  className?: string;
+};
+
+const VIEW_BOX = {
+  w: 120,
+  h: 72,
+};
+const LINE_WIDTH = 2;
+const REPEAT_TIMES = 5;
+const MAX_ACCELERATION = 10;
+
+export const AccelerationWave: FC<Props> = ({ accelerationList, className }) => {
+  const amplitudes = useMemo(
+    () =>
+      accelerationList.map((acceleration) => {
+        if (acceleration >= MAX_ACCELERATION) return 1;
+        return acceleration / MAX_ACCELERATION;
+      }),
+    [accelerationList],
+  );
+
+  const wave = useMemo(
+    () => ({
+      w: VIEW_BOX.w / (REPEAT_TIMES * 2),
+      hList: amplitudes.map((a) => (VIEW_BOX.h * a) / 2),
+    }),
+    [amplitudes],
+  );
+
+  const path = useMemo(() => makeWavePath({ viewBox: VIEW_BOX, wave }), [wave]);
+
+  return (
+    <svg
+      width={VIEW_BOX.w + LINE_WIDTH}
+      height={VIEW_BOX.h + LINE_WIDTH}
+      viewBox={`0 0 ${VIEW_BOX.w + LINE_WIDTH} ${VIEW_BOX.h + LINE_WIDTH}`}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path d={path} stroke="black" strokeWidth={LINE_WIDTH} transform={`translate(0 ${LINE_WIDTH / 2})`} />
+    </svg>
+  );
+};

--- a/src/components/MeasurementStatus.stories.tsx
+++ b/src/components/MeasurementStatus.stories.tsx
@@ -1,0 +1,25 @@
+import type { ComponentMeta, ComponentStoryObj } from '@storybook/react';
+import { MeasurementStatus } from './MeasurementStatus';
+
+export default {
+  component: MeasurementStatus,
+} as ComponentMeta<typeof MeasurementStatus>;
+
+export const Initial: ComponentStoryObj<typeof MeasurementStatus> = {
+  args: {
+    status: 'initial',
+  },
+};
+
+export const Progress: ComponentStoryObj<typeof MeasurementStatus> = {
+  args: {
+    status: 'progress',
+    accelerationList: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  },
+};
+
+export const Completed: ComponentStoryObj<typeof MeasurementStatus> = {
+  args: {
+    status: 'completed',
+  },
+};

--- a/src/components/MeasurementStatus.tsx
+++ b/src/components/MeasurementStatus.tsx
@@ -1,0 +1,34 @@
+import type { FC } from 'react';
+import { AccelerationWave } from './AccelerationWave';
+
+type Props = {
+  status: 'initial' | 'progress' | 'completed';
+  accelerationList?: number[];
+};
+
+export const MeasurementStatus: FC<Props> = ({ status, accelerationList }) => {
+  return (
+    <div className="flex w-136 flex-col justify-center">
+      <AccelerationWave
+        className="mb-16 w-full"
+        accelerationList={
+          {
+            initial: Array(10).fill(0.2),
+            progress: accelerationList ?? Array(10).fill(0),
+            completed: Array(10).fill(1),
+          }[status]
+        }
+      />
+
+      <div className="text-center text-16 font-normal">
+        {
+          {
+            initial: '計測していません',
+            progress: '計測中…',
+            completed: '計測完了',
+          }[status]
+        }
+      </div>
+    </div>
+  );
+};

--- a/src/features/wave/index.ts
+++ b/src/features/wave/index.ts
@@ -1,0 +1,1 @@
+export { makeWavePath } from './make-wave-path';

--- a/src/features/wave/make-wave-path.test.ts
+++ b/src/features/wave/make-wave-path.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { makeWavePath } from './make-wave-path';
+
+describe(makeWavePath.name, () => {
+  it('works correctly', () => {
+    const input: Parameters<typeof makeWavePath>[0] = {
+      viewBox: {
+        w: 100,
+        h: 50,
+      },
+      wave: {
+        w: 20,
+        hList: [10, 30, 20, 40, 50],
+      },
+    };
+    const path = makeWavePath(input);
+    expect(path).toBe('M1 25 v10 h20 v-10 v-30 h20 v30 v20 h20 v-20 v-40 h20 v40 v50 h20 v-50 L101 25');
+  });
+});

--- a/src/features/wave/make-wave-path.ts
+++ b/src/features/wave/make-wave-path.ts
@@ -1,0 +1,23 @@
+type Options = {
+  viewBox: {
+    w: number;
+    h: number;
+  };
+  wave: {
+    w: number;
+    hList: number[];
+  };
+};
+export const makeWavePath = ({ viewBox, wave }: Options) => {
+  const { w, hList } = wave;
+
+  const cycles = hList.map((h, i) => {
+    const n = i % 2 === 0 ? 1 : -1;
+    return `v${h * n} h${w} v${h * -n}`;
+  });
+
+  const firstMove = `M1 ${viewBox.h / 2}`;
+  const lastMove = `L${viewBox.w + 1} ${viewBox.h / 2}`;
+
+  return `${firstMove} ${cycles.join(' ')} ${lastMove}`;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ const keysToObj = (keys, keyToValue) => {
 };
 
 // 昇順で入れて管理する
-const pxs = [16, 32, 40, 48, 320];
+const pxs = [8, 16, 32, 40, 48, 64, 96, 128, 136, 216, 320];
 const PX_PER_REM = 16;
 const remsMap = keysToObj(pxs, (px) => `${px / PX_PER_REM}rem`); // e.g. {1: '1rem', 2: '2rem'}
 


### PR DESCRIPTION
### 関連する Issue
close #20 


### やったこと
`AccelerationWave`コンポーネントの作成
`MeasurementStatus`コンポーネントの作成
`makeWavePath`関数の実装とテスト


### やらないこと
波形をアニメーションにする(やる予定もなし)


### できるようになること（ユーザ目線）
無し


### できなくなること（ユーザ目線）
無し


### 動作のスクリーンショット

`AccelerationWave`
<img width="407" alt="screenshot 2023-02-26 at 15 52 22" src="https://user-images.githubusercontent.com/85025927/221396703-14452cbe-1aa9-4c1e-8d6c-b63732a408d0.png">

`MeasurementStatus`(ステータスごと)
<img width="490" alt="screenshot 2023-02-26 at 15 51 58" src="https://user-images.githubusercontent.com/85025927/221396719-35252d7a-827c-44a0-b0f0-cf6f7015b0aa.png">
<img width="458" alt="screenshot 2023-02-26 at 15 52 04" src="https://user-images.githubusercontent.com/85025927/221396615-48e1267c-3634-47d6-8254-a7e5a93bfb29.png">
<img width="430" alt="screenshot 2023-02-26 at 15 52 11" src="https://user-images.githubusercontent.com/85025927/221396616-ded5b592-73c5-4447-af52-95ec84c30289.png">



### その他
`makeWavePath`はhttps://developer.mozilla.org/ja/docs/Web/SVG/Tutorial/Paths を参考にpathを書いて作りました。
