### PR TITLE
BpmCounterを追加

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,6 +1,7 @@
 <style>
   :root {
     --font-mp1: 'M PLUS 1', sans-serif;
+    --font-dosis: 'Dosis', sans-serif;
   }
   html {
     font-family: var(--font-mp1);

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<link href="https://fonts.googleapis.com/css2?family=M+PLUS+1&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=M+PLUS+1&family=Dosis&display=swap" rel="stylesheet" />

--- a/src/components/BpmCounter.stories.tsx
+++ b/src/components/BpmCounter.stories.tsx
@@ -1,0 +1,12 @@
+import type { ComponentMeta, ComponentStoryFn } from '@storybook/react';
+import { useState } from 'react';
+import { BpmCounter } from './BpmCounter';
+
+export default {
+  component: BpmCounter,
+} as ComponentMeta<typeof BpmCounter>;
+
+export const Default: ComponentStoryFn<typeof BpmCounter> = (args) => {
+  const [bpm, setBpm] = useState<number>(100);
+  return <BpmCounter bpm={bpm} onPlus={() => setBpm(bpm + 1)} onMinus={() => setBpm(bpm - 1)} />;
+};

--- a/src/components/BpmCounter.tsx
+++ b/src/components/BpmCounter.tsx
@@ -1,0 +1,24 @@
+import type { FC } from 'react';
+
+type Props = {
+  bpm: number;
+  onPlus: () => void;
+  onMinus: () => void;
+};
+
+export const BpmCounter: FC<Props> = ({ bpm, onPlus, onMinus }) => {
+  return (
+    <div className="flex w-216 flex-col items-center">
+      <div className="mb-8 flex h-76 items-center gap-x-16 font-dosis">
+        <button onClick={onMinus} className="flex h-32 w-32 items-center justify-center text-64 text-black-700">
+          <span className="relative -top-8">-</span>
+        </button>
+        <div className="w-128 text-center text-96 leading-none text-black">{Math.floor(bpm)}</div>
+        <button onClick={onPlus} className="flex h-32 w-32 items-center justify-center text-64 text-black-700">
+          <span className="relative -top-6">+</span>
+        </button>
+      </div>
+      <div className="text-16 font-bold text-white-600">BPM</div>
+    </div>
+  );
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { M_PLUS_1 } from '@next/font/google';
+import { Dosis, M_PLUS_1 } from '@next/font/google';
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
 
@@ -11,9 +11,18 @@ const mp1Regular = M_PLUS_1({
   variable: '--font-mp1',
 });
 
+const dosisRegular = Dosis({
+  weight: ['400'],
+  subsets: ['latin'],
+  fallback: ['sans-serif'],
+  adjustFontFallback: false,
+  preload: false,
+  variable: '--font-dosis',
+});
+
 export default function ({ Component, pageProps }: AppProps) {
   return (
-    <div className={`${mp1Regular.variable} font-mp1`}>
+    <div className={`${mp1Regular.variable} ${dosisRegular.variable} font-mp1`}>
       <Component {...pageProps} />
     </div>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ const keysToObj = (keys, keyToValue) => {
 };
 
 // 昇順で入れて管理する
-const pxs = [8, 16, 32, 40, 48, 64, 96, 128, 136, 216, 320];
+const pxs = [6, 8, 16, 32, 40, 48, 64, 76, 96, 128, 136, 216, 320];
 const PX_PER_REM = 16;
 const remsMap = keysToObj(pxs, (px) => `${px / PX_PER_REM}rem`); // e.g. {1: '1rem', 2: '2rem'}
 
@@ -21,9 +21,11 @@ module.exports = {
     colors: {
       white: {
         DEFAULT: '#ffffff',
+        600: '#b5bcc7',
       },
       black: {
         DEFAULT: '#000000',
+        700: '#8a817c',
       },
       green: {
         DEFAULT: '#00db00',
@@ -35,6 +37,7 @@ module.exports = {
     borderRadius: { ...remsMap, full: '100%' },
     fontFamily: {
       mp1: ['var(--font-mp1)'],
+      dosis: ['var(--font-dosis)'],
     },
     extend: {
       maxWidth: { ...remsMap, ...screenMap },


### PR DESCRIPTION
### 関連する Issue
close #22 


### やったこと
Google Fontsの [Dosis](https://fonts.google.com/specimen/Dosis)を追加
`BpmCounter`とそのstoriesを追加


### やらないこと
長押しで連続的にBPMを上下させる想定の実装


### できるようになること（ユーザ目線）
無し


### できなくなること（ユーザ目線）
無し


### 動作のスクリーンショット
<img width="511" alt="screenshot 2023-03-04 at 10 34 29" src="https://user-images.githubusercontent.com/85025927/222868583-24c8a4a2-a6dc-4f05-a8f4-4e6b1622c76a.png">


### その他
- Tailwindのpxは8刻みだったと思うのですが、マイナスボタンの位置調整に`6`を使っています。
- 長押しの件は時間が余ったらやろうと思っています。
