### PR TITLE
曲とテンポの取得用の関数追加　

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "jsdom": "^21.1.0",
     "postcss": "^8.4.19",
     "prettier": "^2.7.1",
+    "spotify-types": "^1.0.7",
     "storybook": "^6.5.16",
     "typescript": "4.9.3",
     "vitest": "^0.28.4",

--- a/src/features/track/fetch-track-list-tempo.ts
+++ b/src/features/track/fetch-track-list-tempo.ts
@@ -1,0 +1,35 @@
+import type { AudioFeatures } from 'spotify-types';
+
+const END_POINT = 'https://api.spotify.com/v1/audio-features';
+
+type AudioFeatureResponse = { audio_features: AudioFeatures[] };
+
+type Props = {
+  ids: string[];
+  token: string;
+};
+
+export const fetchTrackListTempo = async ({ ids, token }: Props) => {
+  const formattedQuery = [['ids', ids.join(',')]];
+
+  const params = new URLSearchParams(formattedQuery).toString();
+
+  const response: AudioFeatureResponse | Error = await fetch(`${END_POINT}?${params}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    return new Error();
+  });
+
+  if (response instanceof Error) {
+    return undefined;
+  }
+
+  const tempoList = response.audio_features.map(({ id, tempo }) => ({ id, tempo }));
+
+  return tempoList;
+};

--- a/src/features/track/fetch-user-track-list.ts
+++ b/src/features/track/fetch-user-track-list.ts
@@ -1,0 +1,39 @@
+import type { SavedTrack } from 'spotify-types';
+
+const END_POINT = 'https://api.spotify.com/v1/me/tracks';
+
+type UserTrackListResponse = {
+  href: string;
+  items: SavedTrack[];
+};
+
+type Props = {
+  limit: number | undefined;
+  offset: number | undefined;
+  token: string;
+};
+
+export const fetchUserTrackList = async ({ limit, offset, token }: Props) => {
+  const formattedQuery = [limit !== undefined && ['limit', String(limit)], offset !== undefined && ['offset', String(offset)]].filter(
+    (element): element is string[] => element !== false,
+  );
+
+  const params = new URLSearchParams(formattedQuery).toString();
+
+  const response: UserTrackListResponse | Error = await fetch(`${END_POINT}?${params}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    return new Error();
+  });
+
+  if (response instanceof Error) {
+    return undefined;
+  }
+
+  return response.items;
+};

--- a/src/features/track/index.ts
+++ b/src/features/track/index.ts
@@ -1,0 +1,2 @@
+export * from './fetch-user-track-list';
+export * from './fetch-track-list-tempo';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11618,6 +11618,11 @@ split@0.3:
   dependencies:
     through "2"
 
+spotify-types@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/spotify-types/-/spotify-types-1.0.7.tgz#59c2e16da2ae18b8adb97e07a9e378d8567f4464"
+  integrity sha512-X2n0MYNUpgakGDU7h/vzTvqVJh2f8kAWE9SG5TkJtf3lJcorndK24/8/6+D7Uww8tqUD1VPHg5Lqv4usdVJUvg==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"


### PR DESCRIPTION
### 関連する Issue
#28


### やったこと
今回のプロジェクトで利用する API コール関数を作成しました。
対応したものは下記のものです。

#### お気に入りの曲の取得
```
EndPoint: https://developer.spotify.com/console/get-current-user-saved-tracks/
Doc: https://developer.spotify.com/console/get-current-user-saved-tracks/
```
#### テンポの取得
上記の「お気に入りの曲の取得」のみではテンポの取得が行えないため、レスポンスに含まれる `id` をもとに下記の EndPoint にリクエストを送信し、 テンポを取得します。
```
EndPoint: https://api.spotify.com/v1/audio-features
Doc: https://developer.spotify.com/console/get-audio-features-several-tracks/
```
### やらないこと
- API のコールのつなぎこみ
- BPM 順に Sort


### できるようになること（ユーザ目線）
API の繋ぎ込みは別の PR で対応するため特になし

### できなくなること（ユーザ目線）
特になし


### 動作のスクリーンショット
特になし


### その他
@Toya-Onodera この PR のブランチを Pull して曲の情報を取得できるか確認してほしいです！
Spotify のアカウント持っていないので
