### PR TITLE
曲のリストとテンポを集約する関数の追加

### DIFF
--- a/src/features/track/get-track-list-with-tempo.test.ts
+++ b/src/features/track/get-track-list-with-tempo.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { getTrackListWithTempo } from './get-track-list-with-tempo';
+import * as FetchUserTrackList from './fetch-user-track-list';
+import * as FetchTrackListTempo from './fetch-track-list-tempo';
+
+const mockUserTrackList = [
+  { track: { id: 'A' } },
+  { track: { id: 'B' } },
+  { track: { id: 'C' } },
+  { track: { id: 'D' } },
+  { track: { id: 'E' } },
+];
+
+const mockTempoList = [
+  { id: 'A', tempo: 20 },
+  { id: 'B', tempo: 10 },
+  { id: 'C', tempo: undefined },
+  { id: 'D', tempo: 50 },
+  { id: 'E', tempo: 40 },
+];
+
+describe(getTrackListWithTempo.name, async () => {
+  const fetchUserTrackListSpy = vi.spyOn(FetchUserTrackList, 'fetchUserTrackList');
+  fetchUserTrackListSpy.mockResolvedValue(mockUserTrackList as never);
+
+  const fetchTrackListTempoSpy = vi.spyOn(FetchTrackListTempo, 'fetchTrackListTempo');
+  fetchTrackListTempoSpy.mockResolvedValue(mockTempoList as never);
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('correctly formatted and sorted', async () => {
+    const response = await getTrackListWithTempo({ token: '' });
+    expect(response).toEqual([
+      { track: { id: 'D' }, tempo: 50 },
+      { track: { id: 'E' }, tempo: 40 },
+      { track: { id: 'A' }, tempo: 20 },
+      { track: { id: 'B' }, tempo: 10 },
+    ]);
+  });
+});

--- a/src/features/track/get-track-list-with-tempo.ts
+++ b/src/features/track/get-track-list-with-tempo.ts
@@ -1,0 +1,35 @@
+import type { SavedTrack } from 'spotify-types';
+import { fetchTrackListTempo } from './fetch-track-list-tempo';
+import { fetchUserTrackList } from './fetch-user-track-list';
+
+const LIMIT = 50;
+const OFFSET = 0;
+
+type Props = {
+  token: string;
+};
+
+type TrackListWitTempo = Array<SavedTrack & { tempo: number | undefined }> | undefined;
+
+export const getTrackListWithTempo = async ({ token }: Props): Promise<TrackListWitTempo> => {
+  const userTrackList = await fetchUserTrackList({ token, limit: LIMIT, offset: OFFSET });
+  if (userTrackList === undefined) {
+    return undefined;
+  }
+
+  const trackListTempo = await fetchTrackListTempo({
+    token,
+    ids: userTrackList.map((userTrack) => userTrack.track.id),
+  });
+  if (trackListTempo === undefined) {
+    return undefined;
+  }
+
+  return userTrackList
+    .map((userTrack) => {
+      const tempo = trackListTempo.find(({ id }) => id === userTrack.track.id)?.tempo;
+      return { ...userTrack, tempo };
+    })
+    .filter((track) => track.tempo !== undefined)
+    .sort((a, b) => ((a.tempo as number) > (b.tempo as number) ? -1 : 1));
+};

--- a/src/features/track/index.ts
+++ b/src/features/track/index.ts
@@ -1,2 +1,3 @@
 export * from './fetch-user-track-list';
 export * from './fetch-track-list-tempo';
+export * from './get-track-list-with-tempo';


### PR DESCRIPTION
### 関連する Issue
#28


### やったこと
#29 で取得したテンポとお気に入りの曲を集約し、テンポの降順でソートする関数を追加


### やらないこと
- API コールのつなぎこみ


### できるようになること（ユーザ目線）
特になし


### できなくなること（ユーザ目線）
特になし


### 動作のスクリーンショット
特になし


### その他
特になし
