### PR TITLE
再生・停止・スキップ機能を追加

### DIFF
--- a/src/components/PlayButton.tsx
+++ b/src/components/PlayButton.tsx
@@ -11,12 +11,12 @@ export const PlayButton: FC<Props> = ({ playing, className = '', ...restProps })
       {...restProps}
     >
       {playing ? (
-        <svg width="16" height="20" viewBox="0 0 16 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M0 0V20L15.7143 10L0 0Z" fill="#627294" />
-        </svg>
-      ) : (
         <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M0 0H18V18H0V0Z" fill="#627294" />
+        </svg>
+      ) : (
+        <svg width="16" height="20" viewBox="0 0 16 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M0 0V20L15.7143 10L0 0Z" fill="#627294" />
         </svg>
       )}
     </button>

--- a/src/components/PlaylistRow.tsx
+++ b/src/components/PlaylistRow.tsx
@@ -11,11 +11,12 @@ type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
   playingNow: boolean;
   serialNumber: number;
   song: PlaylistRowSong;
+  onClick?: () => void;
 };
 
-export const PlaylistRow: FC<Props> = ({ playingNow, serialNumber, song, className = '', ...restProps }) => {
+export const PlaylistRow: FC<Props> = ({ playingNow, serialNumber, song, className = '', onClick, ...restProps }) => {
   return (
-    <button className={`flex h-78 items-center p-16 ${playingNow ? 'bg-white-500' : ''} ${className}`} {...restProps}>
+    <button onClick={onClick} className={`flex h-78 items-center p-16 ${playingNow ? 'bg-white-500' : ''} ${className}`} {...restProps}>
       <span className="w-24 text-left font-bold text-black-600">{serialNumber}</span>
       <span className="flex h-full w-[calc(100%-24rem/16-34rem/16)] grow flex-col items-start justify-between">
         <span className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-18 leading-snug">{song.name}</span>

--- a/src/pages/playlist.tsx
+++ b/src/pages/playlist.tsx
@@ -6,15 +6,22 @@ import { getTrackListWithTempo } from '#/features/track';
 import type { NextPage } from 'next';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import useSwr from 'swr';
+
+type PlayState = {
+  isPlaying: boolean;
+  index: number;
+};
 
 const Home: NextPage = () => {
   const router = useRouter();
-  const [playing, setPlaying] = useState<boolean>(false);
+  const [{ isPlaying, index }, setPlayState] = useState<PlayState>({ isPlaying: false, index: 0 });
   const { data: session } = useSession();
   const swrKey = session != null ? () => ({ key: 'getTrackListWithTempo', token: session.user.accessToken }) : null;
   const { data: tracks } = useSwr(swrKey, getTrackListWithTempo);
+
+  const audioRef = useRef<HTMLAudioElement>(null);
 
   const goBackToMeasurement = () => {
     router.push(`/`).catch((err) => {
@@ -22,30 +29,103 @@ const Home: NextPage = () => {
     });
   };
 
+  const play = (url: string, index: number) => {
+    if (audioRef.current == null) return;
+
+    pause();
+    if (audioRef.current.src !== url) {
+      audioRef.current.src = url;
+    }
+    audioRef.current
+      .play()
+      .then(() => {
+        setPlayState({ isPlaying: true, index });
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
+
+  const pause = () => {
+    if (audioRef.current == null) return;
+    audioRef.current.pause();
+    setPlayState((prev) => ({ ...prev, isPlaying: false }));
+  };
+
+  const reset = () => {
+    if (audioRef.current == null) return;
+    audioRef.current.pause();
+    setPlayState({ index: 0, isPlaying: false });
+  };
+
+  const skip = (step: 1 | -1) => {
+    if (tracks == null) return;
+
+    const nextUrl = tracks.at(index + step)?.track.preview_url;
+    if (nextUrl == null) {
+      reset();
+      return;
+    }
+    if (isPlaying) {
+      play(nextUrl, index + step);
+    } else {
+      setPlayState((prev) => {
+        const nextIndex = prev.index + step;
+        const nextUrl = tracks.at(nextIndex)?.track.preview_url;
+        if (nextIndex < 0 || nextIndex >= tracks.length || audioRef.current == null || nextUrl == null) {
+          return prev;
+        }
+        audioRef.current.src = nextUrl;
+        return { ...prev, index: nextIndex };
+      });
+    }
+  };
+
   return (
     <>
       <PlaylistHeader bpm={120} onClose={() => goBackToMeasurement()} className="fixed inset-x-0 top-0" />
       <div className="flex flex-col items-center gap-y-48 pt-174">
         <div className="flex w-216 items-center justify-between">
-          <SkipButton direction="prev" />
-          <PlayButton playing={playing} onClick={() => setPlaying((prev) => !prev)} />
-          <SkipButton direction="next" />
+          <SkipButton direction="prev" onClick={() => skip(-1)} />
+          <PlayButton
+            playing={isPlaying}
+            onClick={() => {
+              if (audioRef.current == null) return;
+
+              if (!audioRef.current.paused) {
+                pause();
+              } else {
+                const url = audioRef.current.src !== '' ? audioRef.current.src : tracks?.at(0)?.track.preview_url;
+                if (url != null) {
+                  play(url, index);
+                }
+              }
+            }}
+          />
+          <SkipButton direction="next" onClick={() => skip(1)} />
         </div>
         <ol className="row-auto grid w-full justify-center px-16">
-          {tracks?.map((track, i) => {
+          {tracks?.map(({ track }, i) => {
             const song: PlaylistRowSong = {
-              name: track.track.name,
-              artistName: track.track.artists.map((a) => a.name).join(', '),
-              seconds: track.track.duration_ms / 1000,
+              name: track.name,
+              artistName: track.artists.map((a) => a.name).join(', '),
+              seconds: track.duration_ms / 1000,
             };
             return (
-              <li key={track.track.id} className="w-[calc(100vw-1rem*2)] max-w-700">
-                <PlaylistRow playingNow={false} serialNumber={i + 1} song={song} className="w-full" />
+              <li key={track.id} className="w-[calc(100vw-1rem*2)] max-w-700">
+                <PlaylistRow
+                  playingNow={i === index}
+                  serialNumber={i + 1}
+                  song={song}
+                  onClick={() => play(track.preview_url, i)}
+                  className="w-full"
+                />
               </li>
             );
           })}
           {tracks != null && tracks.length === 0 && <p>お気に入りの曲がありません。</p>}
         </ol>
+        <audio ref={audioRef} controls className="hidden"></audio>
       </div>
     </>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,7 @@ const keysToObj = (keys, keyToValue) => {
 const pxsToRemsMap = (pxs) => keysToObj(pxs, (px) => `${px / PX_PER_REM}rem`); // e.g. {1: '1rem', 2: '2rem'}
 
 // 昇順で入れて管理する
-const pxs = [0, 6, 8, 12, 16, 18, 24, 32, 36, 40, 48, 56, 64, 76, 78, 96, 112, 128, 136, 144, 216, 240, 320, 700];
+const pxs = [0, 6, 8, 12, 16, 18, 24, 32, 36, 40, 48, 56, 64, 76, 78, 96, 112, 128, 136, 144, 174, 216, 240, 320, 700];
 const PX_PER_REM = 16;
 const remsMap = pxsToRemsMap(pxs);
 


### PR DESCRIPTION
### 関連する Issue
close #45 


### やったこと
- Spotifyのpreview_urlを<audio>タグに渡して再生
- 再生・停止・スキップボタン・曲の行で再生状態を変更


### やらないこと
無し


### できるようになること（ユーザ目線）
無し


### できなくなること（ユーザ目線）
無し


### 動作のスクリーンショット
<!-- スクリーンショットか動画でお願いします -->


### その他
<!-- レビューに関して何か気になることや注意してほしい点を書く -->
