### PR TITLE
BPMが近い順に曲をソート

### DIFF
--- a/src/components/PlaylistHeader.tsx
+++ b/src/components/PlaylistHeader.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 
 type Props = {
-  bpm: number;
+  bpm?: number;
   onClose: () => void;
   className?: string;
 };
@@ -15,10 +15,12 @@ export const PlaylistHeader: FC<Props> = ({ bpm, onClose, className = '' }) => {
         </svg>
       </button>
       <div className="grow pt-16 text-white">
-        <div className="flex w-64 flex-col items-center text-center font-bold">
-          <span className="text-24 leading-none tracking-0.02">BPM</span>
-          <span className="font-dosis text-48 leading-none tracking-0.038">{bpm}</span>
-        </div>
+        {bpm != null && (
+          <div className="flex w-64 flex-col items-center text-center font-bold">
+            <span className="text-24 leading-none tracking-0.02">BPM</span>
+            <span className="font-dosis text-48 leading-none tracking-0.038">{bpm}</span>
+          </div>
+        )}
       </div>
     </header>
   );

--- a/src/components/PlaylistRow.tsx
+++ b/src/components/PlaylistRow.tsx
@@ -1,10 +1,10 @@
-import { formatSeconds } from '#/features/time/format-seconds';
 import type { ButtonHTMLAttributes, FC } from 'react';
 
 export type PlaylistRowSong = {
   name: string;
   artistName: string;
   seconds: number;
+  tempo?: number;
 };
 
 type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -18,13 +18,15 @@ export const PlaylistRow: FC<Props> = ({ playingNow, serialNumber, song, classNa
   return (
     <button onClick={onClick} className={`flex h-78 items-center p-16 ${playingNow ? 'bg-white-500' : ''} ${className}`} {...restProps}>
       <span className="w-24 text-left font-bold text-black-600">{serialNumber}</span>
-      <span className="flex h-full w-[calc(100%-24rem/16-34rem/16)] grow flex-col items-start justify-between">
+      <span className="flex h-full w-[calc(100%-24rem/16-64rem/16)] grow flex-col items-start justify-between">
         <span className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-18 leading-snug">{song.name}</span>
         <span className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-12 leading-snug text-black-600">
           {song.artistName}
         </span>
       </span>
-      <span className="w-36 text-12 text-black-600">{formatSeconds(song.seconds)}</span>
+      <span className="w-64 whitespace-nowrap text-right text-12 text-black-600">
+        {song.tempo != null ? `${Math.floor(song.tempo)} bpm` : undefined}
+      </span>
     </button>
   );
 };

--- a/src/pages/playlist.tsx
+++ b/src/pages/playlist.tsx
@@ -23,6 +23,18 @@ const Home: NextPage = () => {
 
   const audioRef = useRef<HTMLAudioElement>(null);
 
+  const bpmQuery = typeof router.query.bpm === 'object' ? router.query.bpm[0] : router.query.bpm;
+  const bpm = bpmQuery != null ? parseInt(bpmQuery) : undefined;
+
+  const sortedTracks = tracks?.sort((x, y) => {
+    if (bpm == null) return 0;
+    if (x.tempo == null && y.tempo == null) return 0;
+    if (x.tempo != null && y.tempo == null) return -1;
+    if (x.tempo == null && y.tempo != null) return 1;
+
+    return Math.abs((x.tempo as number) - bpm) - Math.abs((y.tempo as number) - bpm);
+  });
+
   const goBackToMeasurement = () => {
     router.push(`/`).catch((err) => {
       console.error(err);
@@ -83,7 +95,7 @@ const Home: NextPage = () => {
 
   return (
     <>
-      <PlaylistHeader bpm={120} onClose={() => goBackToMeasurement()} className="fixed inset-x-0 top-0" />
+      <PlaylistHeader bpm={bpm} onClose={() => goBackToMeasurement()} className="fixed inset-x-0 top-0" />
       <div className="flex flex-col items-center gap-y-48 pt-174">
         <div className="flex w-216 items-center justify-between">
           <SkipButton direction="prev" onClick={() => skip(-1)} />
@@ -105,11 +117,12 @@ const Home: NextPage = () => {
           <SkipButton direction="next" onClick={() => skip(1)} />
         </div>
         <ol className="row-auto grid w-full justify-center px-16">
-          {tracks?.map(({ track }, i) => {
+          {sortedTracks?.map(({ track, tempo }, i) => {
             const song: PlaylistRowSong = {
               name: track.name,
               artistName: track.artists.map((a) => a.name).join(', '),
               seconds: track.duration_ms / 1000,
+              tempo,
             };
             return (
               <li key={track.id} className="w-[calc(100vw-1rem*2)] max-w-700">


### PR DESCRIPTION
### 関連する Issue
close #49 


### やったこと
- BPMで曲をソート
- プレイリストの再生行に再生時間ではなくBPMを表示する


### やらないこと
無し


### できるようになること（ユーザ目線）
BPMをクエリに含めて/playlistに訪れるとお気に入りの曲がBPMに近い順にソートして表示される


### できなくなること（ユーザ目線）
無し


### 動作のスクリーンショット
<!-- スクリーンショットか動画でお願いします -->


### その他
<!-- レビューに関して何か気になることや注意してほしい点を書く -->
